### PR TITLE
feat(flow-sight, mc-mirror-job, navidrome, subscription-manager): Bum…

### DIFF
--- a/charts/flow-sight/Chart.yaml
+++ b/charts/flow-sight/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: flow-sight
 description: A Helm chart for Flow-Sight application
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: "1.1.0"

--- a/charts/flow-sight/README.md
+++ b/charts/flow-sight/README.md
@@ -1,6 +1,6 @@
 # flow-sight
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 A Helm chart for Flow-Sight application
 

--- a/charts/mc-mirror-job/Chart.yaml
+++ b/charts/mc-mirror-job/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: mc-mirror-cronjob
 description: A Helm chart for a Kubernetes CronJob that runs mc mirror
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "RELEASE.2025-07-21T05-28-08Z"

--- a/charts/mc-mirror-job/README.md
+++ b/charts/mc-mirror-job/README.md
@@ -1,6 +1,6 @@
 # mc-mirror-cronjob
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: RELEASE.2025-07-21T05-28-08Z](https://img.shields.io/badge/AppVersion-RELEASE.2025--07--21T05--28--08Z-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: RELEASE.2025-07-21T05-28-08Z](https://img.shields.io/badge/AppVersion-RELEASE.2025--07--21T05--28--08Z-informational?style=flat-square)
 
 A Helm chart for a Kubernetes CronJob that runs mc mirror
 

--- a/charts/navidrome/Chart.yaml
+++ b/charts/navidrome/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/navidrome/README.md
+++ b/charts/navidrome/README.md
@@ -1,6 +1,6 @@
 # navidrome
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.58.0](https://img.shields.io/badge/AppVersion-0.58.0-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.58.0](https://img.shields.io/badge/AppVersion-0.58.0-informational?style=flat-square)
 
 A Helm chart for Navidrome - A modern Music Server and Streamer
 

--- a/charts/subscription-manager/Chart.yaml
+++ b/charts/subscription-manager/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: subscription-manager
 description: A Helm chart for Subscription Manager application
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: "1.0.0"

--- a/charts/subscription-manager/README.md
+++ b/charts/subscription-manager/README.md
@@ -1,6 +1,6 @@
 # subscription-manager
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Helm chart for Subscription Manager application
 


### PR DESCRIPTION
This pull request updates the version numbers for several Helm charts and their accompanying README badges to reflect new chart releases. There are no changes to application logic or functionality—these updates are purely for chart versioning and documentation consistency.

Version updates for Helm charts:

* Bumped chart version for `flow-sight` from `1.1.0` to `1.1.1` in both `Chart.yaml` and the README badge. [[1]](diffhunk://#diff-dffebbf5f16d98cacd1e2d5b110a6d0823562d89caa5101daad52f0c2fab21aeL5-R5) [[2]](diffhunk://#diff-fa1a1165c9f5dba7b1026a8c2e8db8558aef82910eb8905f6b9cd75ac7617f17L3-R3)
* Bumped chart version for `mc-mirror-cronjob` from `0.2.0` to `0.2.1` in both `Chart.yaml` and the README badge. [[1]](diffhunk://#diff-d68875c711bd9a8c027066cd9b6f2206c4d7874ff6d2d827e270929519c4c2e8L5-R5) [[2]](diffhunk://#diff-6cf0fb085ed97fe2d0b44db7037b4014fb71ad22aa034e75b37615761d9a98a3L3-R3)
* Bumped chart version for `navidrome` from `1.0.0` to `1.0.1` in both `Chart.yaml` and the README badge. [[1]](diffhunk://#diff-8d982a852a5d00c9e263b37c2492c33c5601b03a296ec4bb6157b53d92c0cc09L18-R18) [[2]](diffhunk://#diff-3f86c15107a9e4af1d1665322e9073922ad35f9861068db9f6ead8f291239846L3-R3)
* Bumped chart version for `subscription-manager` from `1.1.0` to `1.1.1` in both `Chart.yaml` and the README badge. [[1]](diffhunk://#diff-a99d094033d2bb546cb405b080403164ce440ba1963f86a7304f9b4fd320f454L5-R5) [[2]](diffhunk://#diff-aa12ccb9a4a0e4db4dc61922800dc3908d7dc2c00d2d71ceacbf54d5268b1419L3-R3)


…p version to 1.1.1, 0.2.1, 1.0.1, 1.1.1

- flow-sightのバージョンを1.1.1に更新
- mc-mirror-jobのバージョンを0.2.1に更新
- navidromeのバージョンを1.0.1に更新
- subscription-managerのバージョンを1.1.1に更新