### PR TITLE
fix(summaly): バージョンを0.1.1に更新

### DIFF
--- a/charts/summaly/Chart.yaml
+++ b/charts/summaly/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/summaly/README.md
+++ b/charts/summaly/README.md
@@ -1,6 +1,6 @@
 # summaly
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.2.3-psr.1.0](https://img.shields.io/badge/AppVersion-5.2.3--psr.1.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.2.3-psr.1.0](https://img.shields.io/badge/AppVersion-5.2.3--psr.1.0-informational?style=flat-square)
 
 A Helm chart for Summaly
 
@@ -24,7 +24,7 @@ A Helm chart for Summaly
 | ingress.hosts[0].paths[0].pathType | string | `"Prefix"` |  |
 | ingress.tls | list | `[]` |  |
 | livenessProbe.httpGet.path | string | `"/"` |  |
-| livenessProbe.httpGet.port | string | `"http"` |  |
+| livenessProbe.httpGet.port | int | `3000` |  |
 | livenessProbe.initialDelaySeconds | int | `30` |  |
 | livenessProbe.periodSeconds | int | `10` |  |
 | nameOverride | string | `""` |  |
@@ -33,7 +33,7 @@ A Helm chart for Summaly
 | podLabels | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | readinessProbe.httpGet.path | string | `"/"` |  |
-| readinessProbe.httpGet.port | string | `"http"` |  |
+| readinessProbe.httpGet.port | int | `3000` |  |
 | readinessProbe.initialDelaySeconds | int | `5` |  |
 | readinessProbe.periodSeconds | int | `5` |  |
 | replicaCount | int | `1` |  |

--- a/charts/summaly/values.yaml
+++ b/charts/summaly/values.yaml
@@ -43,7 +43,7 @@ podLabels: {}
 livenessProbe:
   httpGet:
     path: /
-    port: http
+    port: 3000
   initialDelaySeconds: 30
   periodSeconds: 10
 
@@ -51,7 +51,7 @@ livenessProbe:
 readinessProbe:
   httpGet:
     path: /
-    port: http
+    port: 3000
   initialDelaySeconds: 5
   periodSeconds: 5
 


### PR DESCRIPTION
- Chart.yamlのバージョンを0.1.1に更新
- README.mdのバージョンを0.1.1に更新
- values.yamlのlivenessProbeとreadinessProbeのポートを整数型の3000に変更