### PR TITLE
Upgrade summaly

### DIFF
--- a/charts/summaly/Chart.yaml
+++ b/charts/summaly/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "5.2.3-psr.1.0"
+appVersion: "5.2.3-psr.2.0"

--- a/charts/summaly/values.yaml
+++ b/charts/summaly/values.yaml
@@ -43,7 +43,7 @@ podLabels: {}
 livenessProbe:
   httpGet:
     path: /
-    port: 3000
+    port: http
   initialDelaySeconds: 30
   periodSeconds: 10
 
@@ -51,7 +51,7 @@ livenessProbe:
 readinessProbe:
   httpGet:
     path: /
-    port: 3000
+    port: http
   initialDelaySeconds: 5
   periodSeconds: 5
 

--- a/charts/summaly/values.yaml
+++ b/charts/summaly/values.yaml
@@ -42,7 +42,7 @@ podLabels: {}
 # Liveness probe configuration
 livenessProbe:
   httpGet:
-    path: /
+    path: /health
     port: http
   initialDelaySeconds: 30
   periodSeconds: 10
@@ -50,7 +50,7 @@ livenessProbe:
 # Readiness probe configuration
 readinessProbe:
   httpGet:
-    path: /
+    path: /health
     port: http
   initialDelaySeconds: 5
   periodSeconds: 5

--- a/charts/summaly/values.yaml
+++ b/charts/summaly/values.yaml
@@ -9,7 +9,7 @@ fullnameOverride: ""
 # Image configuration
 image:
   repository: ghcr.io/soli0222/summaly
-  tag: "5.2.3-psr.1.0"
+  tag: "5.2.3-psr.2.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
This pull request updates the Helm chart for the Summaly application, mainly to deploy a new application version and improve probe configuration. The changes ensure the chart references the latest container image and use named ports for liveness and readiness probes.

Version and image updates:

* Updated the chart version to `0.1.2` and the application version to `5.2.3-psr.2.0` in `Chart.yaml` to reflect the new release.
* Changed the container image tag to `5.2.3-psr.2.0` in `values.yaml` for consistency with the new application version.

Probe configuration improvements:

* Modified the liveness and readiness probe configurations in `values.yaml` to use the named port `http` instead of the numeric port `3000`, which improves maintainability and compatibility with Kubernetes service definitions.