### PR TITLE
fix(summaly): バージョンを0.1.4および5.2.3-psr.4.0に更新

### DIFF
--- a/charts/summaly/Chart.yaml
+++ b/charts/summaly/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "5.2.3-psr.3.0"
+appVersion: "5.2.3-psr.4.0"

--- a/charts/summaly/README.md
+++ b/charts/summaly/README.md
@@ -1,6 +1,6 @@
 # summaly
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.2.3-psr.1.0](https://img.shields.io/badge/AppVersion-5.2.3--psr.1.0-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.2.3-psr.4.0](https://img.shields.io/badge/AppVersion-5.2.3--psr.4.0-informational?style=flat-square)
 
 A Helm chart for Summaly
 
@@ -14,7 +14,7 @@ A Helm chart for Summaly
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/soli0222/summaly"` |  |
-| image.tag | string | `"5.2.3-psr.1.0"` |  |
+| image.tag | string | `"5.2.3-psr.4.0"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |
@@ -23,8 +23,8 @@ A Helm chart for Summaly
 | ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | ingress.hosts[0].paths[0].pathType | string | `"Prefix"` |  |
 | ingress.tls | list | `[]` |  |
-| livenessProbe.httpGet.path | string | `"/"` |  |
-| livenessProbe.httpGet.port | int | `3000` |  |
+| livenessProbe.httpGet.path | string | `"/health"` |  |
+| livenessProbe.httpGet.port | string | `"http"` |  |
 | livenessProbe.initialDelaySeconds | int | `30` |  |
 | livenessProbe.periodSeconds | int | `10` |  |
 | nameOverride | string | `""` |  |
@@ -32,8 +32,8 @@ A Helm chart for Summaly
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
-| readinessProbe.httpGet.path | string | `"/"` |  |
-| readinessProbe.httpGet.port | int | `3000` |  |
+| readinessProbe.httpGet.path | string | `"/health"` |  |
+| readinessProbe.httpGet.port | string | `"http"` |  |
 | readinessProbe.initialDelaySeconds | int | `5` |  |
 | readinessProbe.periodSeconds | int | `5` |  |
 | replicaCount | int | `1` |  |

--- a/charts/summaly/values.yaml
+++ b/charts/summaly/values.yaml
@@ -9,7 +9,7 @@ fullnameOverride: ""
 # Image configuration
 image:
   repository: ghcr.io/soli0222/summaly
-  tag: "5.2.3-psr.3.0"
+  tag: "5.2.3-psr.4.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
- Chart.yamlのバージョンを0.1.3から0.1.4に更新
- Chart.yamlのappVersionを5.2.3-psr.3.0から5.2.3-psr.4.0に更新
- README.mdのバージョンを0.1.1から0.1.4に更新
- README.mdのappVersionを5.2.3-psr.1.0から5.2.3-psr.4.0に更新
- values.yamlのimage.tagを5.2.3-psr.3.0から5.2.3-psr.4.0に更新