### PR TITLE
fix(summaly): バージョンを0.1.5および5.2.3-psr.4.1に更新

### DIFF
--- a/charts/summaly/Chart.yaml
+++ b/charts/summaly/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "5.2.3-psr.4.0"
+appVersion: "5.2.3-psr.4.1"

--- a/charts/summaly/values.yaml
+++ b/charts/summaly/values.yaml
@@ -9,7 +9,7 @@ fullnameOverride: ""
 # Image configuration
 image:
   repository: ghcr.io/soli0222/summaly
-  tag: "5.2.3-psr.4.0"
+  tag: "5.2.3-psr.4.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -101,6 +101,10 @@ tolerations: []
 affinity: {}
 
 # Environment variables
-env: []
-  # - name: EXAMPLE_ENV
-  #   value: "example_value"
+env:
+  - name: NODE_ENV
+    value: "production"
+  - name: SUMMALY_RESPONSE_TIMEOUT
+    value: 40000
+  - name: SUMMALY_OPERATION_TIMEOUT
+    value: 90000


### PR DESCRIPTION
- Chart.yamlのバージョンを0.1.5に更新
- Chart.yamlのappVersionを5.2.3-psr.4.1に更新
- values.yamlのtagを5.2.3-psr.4.1に更新
- values.yamlに環境変数NODE_ENV、SUMMALY_RESPONSE_TIMEOUT、SUMMALY_OPERATION_TIMEOUTを追加