### PR TITLE
chore(ntc): Bump up 2.0.1

### DIFF
--- a/charts/note-tweet-connector/Chart.yaml
+++ b/charts/note-tweet-connector/Chart.yaml
@@ -15,10 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.0"
+
+# renovate: image=ghcr.io/soli0222/note-tweet-connector
+appVersion: "2.0.1"

--- a/charts/note-tweet-connector/README.md
+++ b/charts/note-tweet-connector/README.md
@@ -1,6 +1,6 @@
 # note-tweet-connector
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
 
 A Helm chart for the Note Tweet Connector
 
@@ -81,24 +81,26 @@ A Helm chart for the Note Tweet Connector
 | resources | object | `{}` |  |
 | secrets.env[0].key | string | `"MISSKEY_HOOK_SECRET"` |  |
 | secrets.env[0].name | string | `"MISSKEY_HOOK_SECRET"` |  |
+| secrets.env[10].key | string | `"IFTTT_KEY"` |  |
+| secrets.env[10].name | string | `"IFTTT_KEY"` |  |
 | secrets.env[1].key | string | `"IFTTT_HOOK_SECRET"` |  |
 | secrets.env[1].name | string | `"IFTTT_HOOK_SECRET"` |  |
 | secrets.env[2].key | string | `"MISSKEY_HOST"` |  |
 | secrets.env[2].name | string | `"MISSKEY_HOST"` |  |
 | secrets.env[3].key | string | `"MISSKEY_TOKEN"` |  |
 | secrets.env[3].name | string | `"MISSKEY_TOKEN"` |  |
-| secrets.env[4].key | string | `"API_KEY"` |  |
-| secrets.env[4].name | string | `"API_KEY"` |  |
-| secrets.env[5].key | string | `"API_KEY_SECRET"` |  |
-| secrets.env[5].name | string | `"API_KEY_SECRET"` |  |
-| secrets.env[6].key | string | `"ACCESS_TOKEN"` |  |
-| secrets.env[6].name | string | `"ACCESS_TOKEN"` |  |
-| secrets.env[7].key | string | `"ACCESS_TOKEN_SECRET"` |  |
-| secrets.env[7].name | string | `"ACCESS_TOKEN_SECRET"` |  |
-| secrets.env[8].key | string | `"IFTTT_EVENT"` |  |
-| secrets.env[8].name | string | `"IFTTT_EVENT"` |  |
-| secrets.env[9].key | string | `"IFTTT_KEY"` |  |
-| secrets.env[9].name | string | `"IFTTT_KEY"` |  |
+| secrets.env[4].key | string | `"MISSKEY_MEDIA_HOST"` |  |
+| secrets.env[4].name | string | `"MISSKEY_MEDIA_HOST"` |  |
+| secrets.env[5].key | string | `"API_KEY"` |  |
+| secrets.env[5].name | string | `"API_KEY"` |  |
+| secrets.env[6].key | string | `"API_KEY_SECRET"` |  |
+| secrets.env[6].name | string | `"API_KEY_SECRET"` |  |
+| secrets.env[7].key | string | `"ACCESS_TOKEN"` |  |
+| secrets.env[7].name | string | `"ACCESS_TOKEN"` |  |
+| secrets.env[8].key | string | `"ACCESS_TOKEN_SECRET"` |  |
+| secrets.env[8].name | string | `"ACCESS_TOKEN_SECRET"` |  |
+| secrets.env[9].key | string | `"IFTTT_EVENT"` |  |
+| secrets.env[9].name | string | `"IFTTT_EVENT"` |  |
 | secrets.secretName | string | `""` |  |
 | securityContext | object | `{}` |  |
 | service.port | int | `8080` |  |

--- a/charts/note-tweet-connector/templates/deployment.yaml
+++ b/charts/note-tweet-connector/templates/deployment.yaml
@@ -34,15 +34,15 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          # args:
-          #   - "-port={{ .Values.args.port }}"
-          #   - "-metrics-port={{ .Values.args.metricsPort }}"
-          #   - "-tracker-expiry={{ .Values.args.trackerExpiry }}"
-          #   - "-read-timeout={{ .Values.args.readTimeout }}"
-          #   - "-write-timeout={{ .Values.args.writeTimeout }}"
-          #   - "-idle-timeout={{ .Values.args.idleTimeout }}"
-          #   - "-shutdown-timeout={{ .Values.args.shutdownTimeout }}"
-          #   - "-log-level={{ .Values.args.logLevel }}"
+          args:
+            - "-port={{ .Values.args.port }}"
+            - "-metrics-port={{ .Values.args.metricsPort }}"
+            - "-tracker-expiry={{ .Values.args.trackerExpiry }}"
+            - "-read-timeout={{ .Values.args.readTimeout }}"
+            - "-write-timeout={{ .Values.args.writeTimeout }}"
+            - "-idle-timeout={{ .Values.args.idleTimeout }}"
+            - "-shutdown-timeout={{ .Values.args.shutdownTimeout }}"
+            - "-log-level={{ .Values.args.logLevel }}"
           ports:
             - name: http
               containerPort: {{ .Values.args.port }}

--- a/charts/note-tweet-connector/values.yaml
+++ b/charts/note-tweet-connector/values.yaml
@@ -129,6 +129,8 @@ secrets:
       key: MISSKEY_HOST
     - name: MISSKEY_TOKEN
       key: MISSKEY_TOKEN
+    - name: MISSKEY_MEDIA_HOST
+      key: MISSKEY_MEDIA_HOST
     - name: API_KEY
       key: API_KEY
     - name: API_KEY_SECRET


### PR DESCRIPTION
This pull request updates the Helm chart for the Note Tweet Connector, primarily to bump the chart and application versions, add a new secret for `MISSKEY_MEDIA_HOST`, and clarify the deployment arguments. These changes improve configuration flexibility and ensure the documentation and templates are up to date.

Version and documentation updates:
* Bumped the chart version to `1.0.2` and the application version to `2.0.1` in `Chart.yaml` and updated the corresponding badges in `README.md`. [[1]](diffhunk://#diff-172e3984a60bbb3993e480d96ff3802b5fe3e28461c4dea4783e9d2d6e064c8aL18-R26) [[2]](diffhunk://#diff-dbca6f4f766c05075986eedd221305ce6c4a29eac11dd92610bac08e8ce685dcL3-R3)

Secrets and configuration improvements:
* Added a new secret key and value for `MISSKEY_MEDIA_HOST` in both `values.yaml` and the documented secrets table in `README.md`. [[1]](diffhunk://#diff-c29196b7d1bd276ad6f51791e68b2855f08890245faa1be3c2ca912c2325d530R132-R133) [[2]](diffhunk://#diff-dbca6f4f766c05075986eedd221305ce6c4a29eac11dd92610bac08e8ce685dcR84-R103)
* Reordered and clarified the secrets list in `README.md` to match the actual configuration, ensuring all required secrets are documented and indexed correctly.

Deployment specification:
* Enabled explicit container arguments in `deployment.yaml` by uncommenting and activating the `args` section, allowing for better control and visibility of runtime configuration.