### PR TITLE
feat(misskey-summarizer): バージョンを0.1.1に更新し、TZDIR環境変数を追加

### DIFF
--- a/charts/misskey-summarizer/Chart.yaml
+++ b/charts/misskey-summarizer/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: misskey-summarizer
 description: A Helm chart for Misskey Summarizer CronJob
 type: application
-version: 0.1.0
-appVersion: "1.0.0"
+version: 0.1.1
+appVersion: "1.0.1"

--- a/charts/misskey-summarizer/Chart.yaml
+++ b/charts/misskey-summarizer/Chart.yaml
@@ -3,4 +3,5 @@ name: misskey-summarizer
 description: A Helm chart for Misskey Summarizer CronJob
 type: application
 version: 0.1.1
+# renovate: image=ghcr.io/soli0222/misskey-summarizer
 appVersion: "1.0.1"

--- a/charts/misskey-summarizer/templates/cronjob.yaml
+++ b/charts/misskey-summarizer/templates/cronjob.yaml
@@ -53,6 +53,8 @@ spec:
                   value: {{ .Values.env.misskeyInstanceUrl | quote }}
                 - name: TZ
                   value: {{ .Values.env.tz | quote }}
+                - name: TZDIR
+                  value: "/usr/share/zoneinfo"
               resources:
                 {{- toYaml .Values.resources | nindent 16 }}
               securityContext:


### PR DESCRIPTION
This pull request updates the Helm chart for the Misskey Summarizer CronJob, focusing on improving timezone configuration and updating versioning information.

**Helm Chart Versioning and Metadata:**
- Updated the chart version to `0.1.1` and the application version to `1.0.1`; also added a `renovate` image comment for automated image updates.

**Timezone Configuration:**
- Added the `TZDIR` environment variable (set to `/usr/share/zoneinfo`) in the CronJob template to improve timezone handling in the container.