### PR TITLE
feat(emoji-bot-gateway): Bump version to 0.1.1

### DIFF
--- a/charts/emoji-bot-gateway/Chart.yaml
+++ b/charts/emoji-bot-gateway/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: emoji-bot-gateway
 description: A Helm chart for Emoji Bot Gateway - Misskey Streaming API based emoji generation bot
 type: application
-version: 0.1.0
+version: 0.1.1
 # renovate: image=ghcr.io/soli0222/emoji-bot-gateway
 appVersion: "1.0.0"

--- a/charts/emoji-bot-gateway/README.md
+++ b/charts/emoji-bot-gateway/README.md
@@ -1,6 +1,6 @@
 # emoji-bot-gateway
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Helm chart for Emoji Bot Gateway - Misskey Streaming API based emoji generation bot
 

--- a/charts/emoji-renderer/Chart.yaml
+++ b/charts/emoji-renderer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/emoji-renderer/README.md
+++ b/charts/emoji-renderer/README.md
@@ -1,6 +1,6 @@
 # emoji-renderer
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.1](https://img.shields.io/badge/AppVersion-1.1.1-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.1](https://img.shields.io/badge/AppVersion-1.1.1-informational?style=flat-square)
 
 A Helm chart for the Emoji Renderer Service - Misskey Custom Emoji image generation microservice
 
@@ -9,7 +9,7 @@ A Helm chart for the Emoji Renderer Service - Misskey Custom Emoji image generat
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| config.defaultFontId | string | `"noto_sans_jp_bold"` |  |
+| config.defaultFontId | string | `"notosansjp_regular"` |  |
 | config.fontDirectory | string | `"./assets/fonts"` |  |
 | config.logLevel | string | `"INFO"` |  |
 | config.maxImageSizeKb | string | `"1024"` |  |


### PR DESCRIPTION
- Chart.yamlのバージョンを0.1.0から0.1.1に更新
- README.mdのバージョンを0.1.0から0.1.1に更新

feat(emoji-renderer): Bump version to 1.0.1

- Chart.yamlのバージョンを1.0.0から1.0.1に更新
- README.mdのバージョンを1.0.0から1.0.1に更新
- README.mdのconfig.defaultFontIdを"noto_sans_jp_bold"から"notosansjp_regular"に変更