### PR TITLE
feat(sui): sui用chartを追加

### DIFF
--- a/charts/sui/Chart.yaml
+++ b/charts/sui/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: sui
+description: A Helm chart for the sui asset forecasting application
+type: application
+version: 0.1.0
+# renovate: image=ghcr.io/soli0222/sui
+appVersion: "1.0.0"

--- a/charts/sui/templates/NOTES.txt
+++ b/charts/sui/templates/NOTES.txt
@@ -1,0 +1,13 @@
+1. Access the application:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+{{- end }}
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  kubectl get svc --namespace {{ .Release.Namespace }} {{ include "sui.fullname" . }} -w
+{{- else }}
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "sui.fullname" . }} 3000:{{ .Values.service.port }}
+{{- end }}
+
+2. PostgreSQL password secret:
+  {{ include "sui.postgresql.secretName" . }} (key: {{ include "sui.postgresql.secretKey" . }})

--- a/charts/sui/templates/_helpers.tpl
+++ b/charts/sui/templates/_helpers.tpl
@@ -1,0 +1,139 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sui.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "sui.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "sui.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "sui.labels" -}}
+helm.sh/chart: {{ include "sui.chart" . }}
+{{ include "sui.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "sui.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "sui.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "sui.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "sui.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve the PostgreSQL host.
+*/}}
+{{- define "sui.postgresql.host" -}}
+{{- if .Values.postgresql.enabled }}
+{{- printf "%s-postgresql" (include "sui.fullname" .) }}
+{{- else }}
+{{- required "externalPostgres.host is required when postgresql.enabled=false" .Values.externalPostgres.host }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve the PostgreSQL port.
+*/}}
+{{- define "sui.postgresql.port" -}}
+{{- if .Values.postgresql.enabled }}
+{{- .Values.postgresql.service.port }}
+{{- else }}
+{{- .Values.externalPostgres.port }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve the PostgreSQL database.
+*/}}
+{{- define "sui.postgresql.database" -}}
+{{- if .Values.postgresql.enabled }}
+{{- .Values.postgresql.auth.database }}
+{{- else }}
+{{- required "externalPostgres.database is required when postgresql.enabled=false" .Values.externalPostgres.database }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve the PostgreSQL user.
+*/}}
+{{- define "sui.postgresql.user" -}}
+{{- if .Values.postgresql.enabled }}
+{{- .Values.postgresql.auth.user }}
+{{- else }}
+{{- required "externalPostgres.user is required when postgresql.enabled=false" .Values.externalPostgres.user }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve the PostgreSQL password secret name.
+*/}}
+{{- define "sui.postgresql.secretName" -}}
+{{- if .Values.postgresql.enabled }}
+{{- default (printf "%s-postgresql" (include "sui.fullname" .)) .Values.postgresql.auth.existingSecret }}
+{{- else }}
+{{- required "externalPostgres.existingSecret is required when postgresql.enabled=false" .Values.externalPostgres.existingSecret }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve the PostgreSQL password secret key.
+*/}}
+{{- define "sui.postgresql.secretKey" -}}
+{{- if .Values.postgresql.enabled }}
+{{- default "POSTGRES_PASSWORD" .Values.postgresql.auth.existingSecretKey }}
+{{- else }}
+{{- default "password" .Values.externalPostgres.existingSecretKey }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve the PostgreSQL PVC name.
+*/}}
+{{- define "sui.postgresql.pvcName" -}}
+{{- if .Values.postgresql.persistence.existingClaim }}
+{{- .Values.postgresql.persistence.existingClaim }}
+{{- else }}
+{{- printf "%s-postgresql" (include "sui.fullname" .) }}
+{{- end }}
+{{- end }}

--- a/charts/sui/templates/deployment.yaml
+++ b/charts/sui/templates/deployment.yaml
@@ -34,13 +34,6 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
-            - sh
-            - -c
-            - |
-              export DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
-              node node_modules/prisma/build/index.js migrate deploy --schema prisma/schema.prisma
-              exec node dist/index.js
           ports:
             - name: http
               containerPort: {{ .Values.containerPort }}
@@ -65,6 +58,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "sui.postgresql.secretName" . }}
                   key: {{ include "sui.postgresql.secretKey" . }}
+            - name: DATABASE_URL
+              value: "postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@$(POSTGRES_HOST):$(POSTGRES_PORT)/$(POSTGRES_DB)"
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/sui/templates/deployment.yaml
+++ b/charts/sui/templates/deployment.yaml
@@ -1,0 +1,92 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sui.fullname" . }}
+  labels:
+    {{- include "sui.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "sui.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "sui.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "sui.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              export DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
+              node node_modules/prisma/build/index.js migrate deploy --schema prisma/schema.prisma
+              exec node dist/index.js
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.containerPort | quote }}
+            - name: STATIC_DIR
+              value: {{ .Values.config.staticDir | quote }}
+            - name: TZ
+              value: {{ .Values.config.timeZone | quote }}
+            - name: POSTGRES_HOST
+              value: {{ include "sui.postgresql.host" . | quote }}
+            - name: POSTGRES_PORT
+              value: {{ include "sui.postgresql.port" . | quote }}
+            - name: POSTGRES_DB
+              value: {{ include "sui.postgresql.database" . | quote }}
+            - name: POSTGRES_USER
+              value: {{ include "sui.postgresql.user" . | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sui.postgresql.secretName" . }}
+                  key: {{ include "sui.postgresql.secretKey" . }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/sui/templates/ingress.yaml
+++ b/charts/sui/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "sui.fullname" . }}
+  labels:
+    {{- include "sui.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "sui.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/sui/templates/postgresql-deployment.yaml
+++ b/charts/sui/templates/postgresql-deployment.yaml
@@ -1,0 +1,72 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sui.fullname" . }}-postgresql
+  labels:
+    {{- include "sui.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "sui.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: postgresql
+  template:
+    metadata:
+      labels:
+        {{- include "sui.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: postgresql
+    spec:
+      containers:
+        - name: postgresql
+          image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          ports:
+            - name: postgresql
+              containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.postgresql.auth.database | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.postgresql.auth.user | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sui.postgresql.secretName" . }}
+                  key: {{ include "sui.postgresql.secretKey" . }}
+            - name: TZ
+              value: {{ .Values.config.timeZone | quote }}
+          {{- if .Values.postgresql.persistence.enabled }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          {{- end }}
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+          resources:
+            {{- toYaml .Values.postgresql.resources | nindent 12 }}
+      {{- if .Values.postgresql.persistence.enabled }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "sui.postgresql.pvcName" . }}
+      {{- end }}
+{{- end }}

--- a/charts/sui/templates/postgresql-pvc.yaml
+++ b/charts/sui/templates/postgresql-pvc.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.postgresql.enabled .Values.postgresql.persistence.enabled (not .Values.postgresql.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "sui.postgresql.pvcName" . }}
+  labels:
+    {{- include "sui.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+spec:
+  accessModes:
+    {{- toYaml .Values.postgresql.persistence.accessModes | nindent 4 }}
+  {{- if .Values.postgresql.persistence.storageClass }}
+  storageClassName: {{ .Values.postgresql.persistence.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.postgresql.persistence.size }}
+{{- end }}

--- a/charts/sui/templates/postgresql-service.yaml
+++ b/charts/sui/templates/postgresql-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sui.fullname" . }}-postgresql
+  labels:
+    {{- include "sui.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.postgresql.service.port }}
+      targetPort: postgresql
+      protocol: TCP
+      name: postgresql
+  selector:
+    {{- include "sui.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+{{- end }}

--- a/charts/sui/templates/service.yaml
+++ b/charts/sui/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sui.fullname" . }}
+  labels:
+    {{- include "sui.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "sui.selectorLabels" . | nindent 4 }}

--- a/charts/sui/templates/serviceaccount.yaml
+++ b/charts/sui/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sui.serviceAccountName" . }}
+  labels:
+    {{- include "sui.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/sui/values.yaml
+++ b/charts/sui/values.yaml
@@ -1,0 +1,97 @@
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  repository: ghcr.io/soli0222/sui
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+podSecurityContext: {}
+securityContext: {}
+
+replicaCount: 1
+
+containerPort: 3000
+
+service:
+  type: ClusterIP
+  port: 3000
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: example.tld
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 20
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+config:
+  timeZone: Asia/Tokyo
+  staticDir: /app/frontend-dist
+
+postgresql:
+  enabled: true
+  image:
+    repository: postgres
+    tag: "18.3-bookworm"
+    pullPolicy: IfNotPresent
+  service:
+    port: 5432
+  persistence:
+    enabled: true
+    existingClaim: ""
+    storageClass: ""
+    size: 1Gi
+    accessModes:
+      - ReadWriteOnce
+  auth:
+    database: sui
+    user: sui
+    existingSecret: ""
+    existingSecretKey: POSTGRES_PASSWORD
+  resources: {}
+
+externalPostgres:
+  host: ""
+  port: 5432
+  database: ""
+  user: ""
+  existingSecret: ""
+  existingSecretKey: password
+
+extraEnv: []


### PR DESCRIPTION
This pull request introduces a new Helm chart for the `sui` asset forecasting application, enabling Kubernetes-based deployment and management. The chart provides a flexible setup for both the application and its PostgreSQL database, supporting configuration for persistence, secrets, and external database connections. The most important changes are grouped below:

**Helm Chart Structure and Core Templates**

* Added initial Helm chart files for `sui`, including `Chart.yaml`, `values.yaml`, and templates for deployment, service, ingress, and service account, establishing the basic structure and configuration options for Kubernetes deployment. [[1]](diffhunk://#diff-9308926b9032a1022252c57a08211be013f30c248f188970fc534320248ea051R1-R7) [[2]](diffhunk://#diff-0aab74fbfe9baa7311ac71564f605c018b86a2d049dfced7cd54aa08749ebcc6R1-R97) [[3]](diffhunk://#diff-183a9cda2cc94bdbcc853d2d5d854d85a1b89a688ef67aac0b45474883308c63R1-R92) [[4]](diffhunk://#diff-cc7ee35858def258608e935cd4ca07acff18f74f1a26df34ed1d785950679ee0R1-R15) [[5]](diffhunk://#diff-788a13b7ddc1f4f33096a92cdbac73035e2f82734b03e230f11358265db6e614R1-R35) [[6]](diffhunk://#diff-c855f722aaba042577f71a8c825115a44354d8ba8bfb773319ec61ada304b183R1-R12)

**PostgreSQL Integration**

* Provided templates for PostgreSQL deployment, service, and persistent volume claim, allowing the application to use an internal or external PostgreSQL database, with support for secrets and storage configuration. [[1]](diffhunk://#diff-51ff2261ea098910c4971d59f5e3a49019e12f36d5c0e313837dd7291ac17c61R1-R72) [[2]](diffhunk://#diff-206f628ac0920187b2366a6f703375f7bfa7cb6a1108d7497b4243a139b7bdbfR1-R19) [[3]](diffhunk://#diff-bda4462a5432fe216ccfccb97237157bf27f11fa88ecd9726e0a6b5aeb4b78c2R1-R18)
* Implemented helper functions in `_helpers.tpl` to resolve PostgreSQL connection details, secret names, and PVC names, enabling flexible database configuration and secret management.

**Configuration and Customization**

* Added extensive configuration options in `values.yaml` for image, resources, probes, ingress, service, pod labels, affinity, tolerations, and environment variables, making the chart highly customizable for different deployment scenarios.

**User Guidance**

* Included a `NOTES.txt` template to provide post-install instructions, such as accessing the application and locating the PostgreSQL password secret, improving user experience and deployment clarity.