### PR TITLE
chore(rss-fetcher): バージョンを0.3.0に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ helm uninstall my-release
 | [mk-stream](#mk-stream) | 1.0.0 | 2.0.0 | A Helm chart for Kubernetes |
 | [navidrome](#navidrome) | 2.3.0 | 0.61.1 | A Helm chart for Navidrome - A modern Music Server and Streamer |
 | [note-tweet-connector](#note-tweet-connector) | 1.0.3 | 2.0.2 | A Helm chart for the Note Tweet Connector |
-| [rss-fetcher](#rss-fetcher) | 0.2.0 | 1.2.0 | A Helm chart for RSS Fetcher application |
+| [rss-fetcher](#rss-fetcher) | 0.3.0 | 1.3.0 | A Helm chart for RSS Fetcher application |
 | [spotify-nowplaying](#spotify-nowplaying) | 3.0.3 | 4.2.0 | A Helm chart for the Spotify Now Playing application |
 | [spotify-reblend](#spotify-reblend) | 0.1.5 | 1.2.0 | A Helm chart for Spotify ReBlend application |
 | [subscription-manager](#subscription-manager) | 1.1.1 | 1.0.0 | A Helm chart for Subscription Manager application |

--- a/charts/rss-fetcher/Chart.yaml
+++ b/charts/rss-fetcher/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: rss-fetcher
 description: A Helm chart for RSS Fetcher application
 type: application
-version: 0.2.0
+version: 0.3.0
 # renovate: image=ghcr.io/soli0222/rss-fetcher
-appVersion: "1.2.0"
+appVersion: "1.3.0"

--- a/charts/rss-fetcher/README.md
+++ b/charts/rss-fetcher/README.md
@@ -1,6 +1,6 @@
 # rss-fetcher
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.3.0](https://img.shields.io/badge/AppVersion-1.3.0-informational?style=flat-square)
 
 A Helm chart for RSS Fetcher application
 
@@ -10,10 +10,14 @@ A Helm chart for RSS Fetcher application
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | config.existingSecret | string | `""` |  |
-| config.feeds[0] | string | `"https://rss.nytimes.com/services/xml/rss/nyt/Technology.xml"` |  |
-| config.feeds[1] | string | `"https://www.youtube.com/feeds/videos.xml?channel_id=UCRcLAVTbmx2-iNcXSsupdNA"` |  |
+| config.feeds[0].name | string | `"nytimes-technology"` |  |
+| config.feeds[0].url | string | `"https://rss.nytimes.com/services/xml/rss/nyt/Technology.xml"` |  |
+| config.feeds[1].name | string | `"youtube-channel"` |  |
+| config.feeds[1].url | string | `"https://www.youtube.com/feeds/videos.xml?channel_id=UCRcLAVTbmx2-iNcXSsupdNA"` |  |
+| config.initial_warmup_stable_observations | int | `2` |  |
 | config.interval | string | `"10m"` |  |
-| config.skip_initial_notify | bool | `false` |  |
+| config.max_notifications_per_feed_per_run | int | `10` |  |
+| config.skip_initial_notify | bool | `true` |  |
 | config.webhooks[0].name | string | `"my-webhook"` |  |
 | config.webhooks[0].post_interval | string | `"2s"` |  |
 | config.webhooks[0].provider | string | `"generic"` |  |

--- a/charts/rss-fetcher/templates/configmap.yaml
+++ b/charts/rss-fetcher/templates/configmap.yaml
@@ -10,6 +10,8 @@ data:
     {{- toYaml .Values.config.feeds | nindent 4 }}
     interval: {{ .Values.config.interval }}
     skip_initial_notify: {{ .Values.config.skip_initial_notify }}
+    initial_warmup_stable_observations: {{ .Values.config.initial_warmup_stable_observations }}
+    max_notifications_per_feed_per_run: {{ .Values.config.max_notifications_per_feed_per_run }}
     store:
       {{- if or .Values.valkey.enabled .Values.externalValkey.host }}
       type: valkey

--- a/charts/rss-fetcher/values.yaml
+++ b/charts/rss-fetcher/values.yaml
@@ -34,15 +34,25 @@ config:
   # Interval for checking RSS feeds
   interval: "10m"
 
-  # If true, on the first run for a feed (no prior state), record the latest
-  # item time as the baseline without sending notifications. Subsequent runs
-  # notify only items newer than the baseline.
-  skip_initial_notify: false
-    
+  # If true, do not notify while a feed has no comparable state yet.
+  # The fetcher records a baseline first, waits until the observed latest item
+  # is stable, and only then starts notifying future items.
+  skip_initial_notify: true
+
+  # Number of consecutive observations with the same latest item time required
+  # before a warming feed becomes ready.
+  initial_warmup_stable_observations: 2
+
+  # Suppress and advance the baseline if one feed would notify more than this
+  # many items in a single run. Set 0 to disable this guard.
+  max_notifications_per_feed_per_run: 10
+
   # feeds.yaml content
   feeds:
-    - https://rss.nytimes.com/services/xml/rss/nyt/Technology.xml
-    - https://www.youtube.com/feeds/videos.xml?channel_id=UCRcLAVTbmx2-iNcXSsupdNA
+    - name: nytimes-technology
+      url: https://rss.nytimes.com/services/xml/rss/nyt/Technology.xml
+    - name: youtube-channel
+      url: https://www.youtube.com/feeds/videos.xml?channel_id=UCRcLAVTbmx2-iNcXSsupdNA
 
   # Webhooks configuration
   # If existingSecret is set, it will be used and 'webhooks' content will be ignored.


### PR DESCRIPTION
- README.mdのrss-fetcherのバージョンを0.3.0に更新
- Chart.yamlのバージョンを0.3.0に更新し、appVersionを1.3.0に更新
- rss-fetcherのREADME.mdでバージョン情報を0.3.0に更新
- configmap.yamlにinitial_warmup_stable_observationsとmax_notifications_per_feed_per_runを追加
- values.yamlに新しい設定項目initial_warmup_stable_observationsとmax_notifications_per_feed_per_runを追加