### PR TITLE
feat: auto-bump chart versions in renovate PRs and automerge app updates

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,31 @@
+name: Lint Charts
+
+on:
+  pull_request:
+    paths:
+      - 'charts/**'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: '3.14'
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.8.0
+
+      - name: Run chart-testing (lint)
+        run: ct lint --target-branch main --validate-maintainers=false

--- a/renovate.json5
+++ b/renovate.json5
@@ -61,7 +61,9 @@
       matchDatasources: [
         'docker',
       ],
-      automerge: false,
+      automerge: true,
+      automergeType: 'pr',
+      platformAutomerge: false,
       commitMessagePrefix: 'chore(app):',
       labels: [
         'dependencies',
@@ -101,6 +103,17 @@
   ],
   postUpdateOptions: [
     'helmUpdateSubChartArchives',
+  ],
+  bumpVersions: [
+    {
+      filePatterns: [
+        '{{packageFileDir}}/Chart.yaml',
+      ],
+      matchStrings: [
+        '(?:^|\\n)version:\\s*(?<version>[^\\s]+)',
+      ],
+      bumpType: 'patch',
+    },
   ],
   semanticCommits: 'enabled',
   prCreation: 'immediate',


### PR DESCRIPTION
## 概要

Renovate 更新時のチャートバージョン管理を、人間による `/bump` コメントから自動化し、自チームアプリの minor/patch 更新を自動マージできるようにします。破壊的な CI 変更も許容する前提で実施しました。

## 新しいフロー

1. Renovate がアプリイメージ (values.yaml のタグ、または Chart.yaml の `appVersion`) を更新する PR を作成
2. 新設した `bumpVersions` 設定により、同じ PR 内で対象チャートの `Chart.yaml` の `version` が自動的に patch bump される（人間の `/bump` コメント不要）
3. 新設の `ct lint` ワークフロー (`.github/workflows/lint.yaml`) が `charts/**` を触る全 PR をゲート。`ct lint --target-branch main` は「main に対してバージョンが上がっているか」も検証するため、旧来のコメント方式チェックの機械的な代替になる
4. 自チームアプリ (`ghcr.io/soli0222/*`, `soli0222/*`, ラベル `app-update`) の minor/patch 更新は `automerge: true` (`automergeType: 'pr'`, `platformAutomerge: false`) にしたため、Renovate の 3 時間おきのスケジュール実行時に PR チェック（新設の ct lint 含む）が green であれば自動マージされる。major 更新は既存の `major-update` ルール（配列の後方にあるため優先）により引き続き手動マージ
5. main への push を `release.yaml` (chart-releaser) が検知してチャートを公開

## 変更点

### `renovate.json5`
- `bumpVersions` を追加。`{{packageFileDir}}/Chart.yaml` の `version:` 行（`apiVersion: v2` と誤マッチしないよう `(?:^|\n)` アンカー付き）を patch bump
- 自チームアプリの packageRule を `automerge: false` → `automerge: true` (+ `automergeType: 'pr'`, `platformAutomerge: false`) に変更。サードパーティ Docker ルール (postgres/gotson 等) は `automerge: false` のまま
- **注意点**: 自チームアプリの更新は `values.yaml` (helm-values manager) と `Chart.yaml` (appVersion 用カスタム regex manager) の両方を同一 PR で触ることがあり、その場合 `bumpVersions` によって patch bump が二重に走る可能性があります。実害はなくチャートバージョンが1つ余分に進むだけなので許容としています
- `npx --yes --package renovate@latest -- renovate-config-validator renovate.json5` で検証済み（`INFO: Config validated successfully against 1 file(s)`）。ローカルにキャッシュされていた古い renovate (37.x) では `bumpVersions` / `managerFilePatterns` が未知のオプションとしてエラーになったが、これは古いバージョンの制限であり、実運用の `renovatebot/github-action@v46.x` では動作する設定

### `.github/workflows/lint.yaml` (新規)
- `pull_request` (charts/** に変更があるとき) トリガー
- `azure/setup-helm@v5.0.1` → `actions/setup-python@v6.2.0` → `helm/chart-testing-action@v2.8.0` の順にセットアップし `ct lint --target-branch main --validate-maintainers=false` を実行 (`fetch-depth: 0` で main との差分を取れるようにチェックアウト)
- charts に `maintainers` フィールドが無いため `--validate-maintainers=false`
- ローカルに `ct` バイナリが無かったため `ct lint --all` 相当の直接検証はできませんでしたが、`helm lint charts/rss-fetcher` と `helm lint charts/misskey` はどちらも `0 chart(s) failed`（`icon is recommended` の info のみ）で通過を確認済み

### 変更していないもの
- `auto-bump-chart-version.yaml` (人間向けの `/bump` コメントフローはそのまま維持)
- `release.yaml`

`actionlint` と `python3 -c yaml.safe_load` で新規・変更ワークフローを検証済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)