### PR TITLE
fix: relax yamllint style rules in chart lint gate

### DIFF
--- a/.github/lintconf.yaml
+++ b/.github/lintconf.yaml
@@ -1,0 +1,60 @@
+---
+# Based on https://github.com/helm/chart-testing/blob/main/etc/lintconf.yaml
+# Style-only rules are demoted to `level: warning` so `ct lint` only fails on
+# real problems (helm lint issues, syntax errors, chart version not bumped),
+# not cosmetic YAML formatting in pre-existing files.
+rules:
+  braces:
+    level: warning
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  brackets:
+    level: warning
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  colons:
+    level: warning
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    level: warning
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments:
+    level: warning
+    require-starting-space: true
+    min-spaces-from-content: 2
+  comments-indentation:
+    level: warning
+  document-end: disable
+  document-start:
+    level: warning
+  empty-lines:
+    level: warning
+    max: 2
+    max-start: 0
+    max-end: 0
+  hyphens:
+    level: warning
+    max-spaces-after: 1
+  indentation:
+    level: warning
+    spaces: consistent
+    indent-sequences: whatever      # - list indentation will handle both indentation and without
+    check-multi-line-strings: false
+  key-duplicates: enable
+  line-length:
+    level: warning
+  new-line-at-end-of-file:
+    level: warning
+  new-lines:
+    type: unix
+  trailing-spaces:
+    level: warning
+  truthy:
+    level: warning

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,4 +28,4 @@ jobs:
         uses: helm/chart-testing-action@v2.8.0
 
       - name: Run chart-testing (lint)
-        run: ct lint --target-branch main --validate-maintainers=false
+        run: ct lint --target-branch main --validate-maintainers=false --lint-conf .github/lintconf.yaml


### PR DESCRIPTION
## Problem

The new `ct lint` gate (`lint.yaml`) failed on pre-existing cosmetic YAML issues — ct's default yamllint config errors on things like trailing whitespace, and several charts (e.g. `charts/navidrome`) have plenty of it. The gate should enforce `helm lint` correctness and the chart-version-bump check, not style.

## Fix

- Added `.github/lintconf.yaml`, based on [chart-testing's default lintconf](https://github.com/helm/chart-testing/blob/main/etc/lintconf.yaml), with style-only rules (`trailing-spaces`, `indentation`, `line-length`, `comments`, `comments-indentation`, `document-start`, `empty-lines`, `hyphens`, `colons`, `commas`, `brackets`, `braces`, `new-line-at-end-of-file`) demoted to `level: warning`, which yamllint does not fail on. `key-duplicates` and `truthy` stay enabled at their original (error/warning) levels.
- `.github/workflows/lint.yaml` now passes `--lint-conf .github/lintconf.yaml` to `ct lint`.

## Verification

`yamllint` wasn't preinstalled locally, so I installed it via `pip3 install --user yamllint` and ran it with the new config against three existing files:

- `charts/navidrome/values.yaml` — 27 warnings (trailing-spaces, line-length, comments-indentation, document-start), exit code 0
- `charts/rss-fetcher/values.yaml` — 5 warnings, exit code 0
- `charts/misskey/Chart.yaml` — 2 warnings, exit code 0

All problems reported as warnings only; exit code 0 in every case, confirming the gate will no longer fail on this pre-existing style debt.

Note: this PR only touches `.github/`, not `charts/**`, so the `lint.yaml` gate itself won't trigger on this PR — that's expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)