### PR TITLE
chore: drop reviewers from automerge-target renovate PRs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -56,6 +56,8 @@
       automerge: true,
       automergeType: 'pr',
       platformAutomerge: false,
+      reviewers: [],
+      assignees: [],
     },
     {
       matchDatasources: [
@@ -73,6 +75,8 @@
         '/^ghcr\\.io/soli0222/.*/',
         '/^soli0222/.*/',
       ],
+      reviewers: [],
+      assignees: [],
     },
     {
       matchDatasources: [
@@ -98,6 +102,12 @@
       automerge: false,
       labels: [
         'major-update',
+      ],
+      reviewers: [
+        'Soli0222',
+      ],
+      assignees: [
+        'Soli0222',
       ],
     },
   ],


### PR DESCRIPTION
## Summary

Renovate PRs that get automerged (`github-actions` updates and own-app minor/patch updates) don't need a human reviewer/assignee pinged. This adds `reviewers: []` / `assignees: []` to those two packageRules, which clears the top-level `reviewers`/`assignees` for matching PRs (packageRule array fields replace, not merge, the config-level value).

The final `matchUpdateTypes: ['major']` rule now explicitly sets `reviewers: ['Soli0222']` / `assignees: ['Soli0222']`, since it runs later in the array and therefore overrides the own-app rule for major bumps too (including own-app majors, which the earlier rule would otherwise have cleared) — majors stay manual and always request review.

The third-party docker rule is untouched and still inherits the top-level reviewers/assignees.

## Validation

`npx --yes --package renovate@latest -- renovate-config-validator renovate.json5` → `INFO: Config validated successfully against 1 file(s)`.

Note: running the same command without `@latest` picks up a stale cached older renovate (37.x) that errors on unrelated pre-existing options (`bumpVersions`, `managerFilePatterns`) — a known artifact of that cached version, not related to this change; validated clean with the current renovate release instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)